### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.sveltekit-application
+++ b/Dockerfile.sveltekit-application
@@ -1,0 +1,11 @@
+FROM node:16-alpine
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY prisma ./prisma
+RUN npx prisma generate
+COPY . .
+RUN yarn build
+ENV JWT_SECRET=your_jwt_secret_here
+EXPOSE 3000
+CMD ["yarn", "preview", "--port", "3000"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO trpc-sveltekit-example
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,45 @@
+namespace: trpc-sveltekit-example
+
+sveltekit-application:
+  defines: runnable
+  metadata:
+    name: sveltekit-application
+    description: Frontend and backend server for the bookstall application.
+    icon: https://emojiapi.dev/api/v1/globe_with_meridians.svg
+  containers:
+    sveltekit-application:
+      image: env-6241.registry.local/sveltekit-application:main-8lm8o0
+      build: .
+      dockerfile: Dockerfile.sveltekit-application
+  services:
+    http-server-port:
+      description: Port for the HTTP server
+      container: sveltekit-application
+      port: 3000
+      host-port: 3000
+      publish: true
+      protocol: tcp
+  connections:
+    sqlite-database-connection:
+      target: trpc-sveltekit-example/sqlite-database
+      service: '!!!SETME!!!'
+      optional: true
+      description: Connection to the SQLite database
+  variables:
+    jwt-secret:
+      env: JWT_SECRET
+      type: string
+      value: '!!!SETME!!!'
+      description: Secret key for JWT authentication
+
+stack:
+  defines: group
+  members:
+    - trpc-sveltekit-example/sveltekit-application
+  metadata:
+    name: trpc-sveltekit-example
+    description: >-
+      A SvelteKit application that demonstrates the use of tRPC for building
+      type-safe APIs. It includes a backend server component and uses SQLite as
+      the database.
+    icon: https://emojiapi.dev/api/v1/blue_book.svg


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for SvelteKit Application

## Changes Made

- **Dockerfile Creation**: I've created a Dockerfile for the SvelteKit application, which includes the necessary steps to build and serve the application. During the build process, I encountered an issue where `@prisma/client` had not been initialized. To resolve this, I modified the Dockerfile to run `prisma generate` after installing dependencies and before building the application. This ensures that Prisma ORM is set up correctly to interact with the SQLite database.
- **Port Configuration**: Initially, the Dockerfile exposed port 3000, but the application was served on the default Vite port. I updated the Dockerfile to ensure that the `vite preview` command serves the application on port 3000, aligning the exposed port with the application's runtime port.
- **Environment Variables**: The Dockerfile sets the `JWT_SECRET` environment variable, which is required by the application. No other environment variables were necessary for the application's operation.

## Monk.io Configuration

- **Monk Configuration**: I've added a `monk.yaml` file containing the Monk.io configuration for the application, along with a `MANIFEST` file listing all files containing Monk configurations.
- **Service Dependencies**: The service is currently failing to run due to being in isolation. It requires the `sqlite-database` service to be configured and running to function correctly. The configuration details for the `sqlite-database` service are needed to set the correct target port for the `sqlite-database-connection`.

## Instructions for Continuation

- **Database Service Configuration**: The configuration for the `sqlite-database` service needs to be provided to complete the setup. Once the database service details are available, the target port for the `sqlite-database-connection` should be determined and set in the Monk.io configuration.
- **Merge and Deployment**: After the database service configuration is complete and verified, the PR can be merged. The application will then be re-deployed on each subsequent push, ensuring that the containerized application is up-to-date.

## Summary

The SvelteKit application is now containerized with a Dockerfile that correctly initializes Prisma ORM and serves the application on the specified port. The Monk.io configuration is in place, pending the completion of the `sqlite-database` service configuration. Once the database service is configured, the application should be fully operational in a containerized environment.